### PR TITLE
fix: install bash in runtime stage to support bash -c execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ WORKDIR /app
 
 # Install runtime dependencies
 RUN apk add --no-cache \
+    bash \
     libreoffice \
     ttf-liberation \
     libwebp \


### PR DESCRIPTION
This PR fixes the issue where the runtime container fails with:
  `exec: "bash": executable file not found in $PATH`

LibreOffice command is invoked via `bash -c` in the Go code.
Adding `bash` to the runtime stage resolves this.

Tested locally with Docker build and confirmed it works.

---

I noticed that there was a previous PR (#24) that also added `bash` to the Dockerfile.
However, that change only added `bash` to the **build stage** (`golang:1.22-alpine`), which does not affect the final runtime image based on `alpine:3.19`.

This PR specifically installs `bash` in the **runtime stage**, ensuring it is available when the application executes `bash -c` at runtime.
Thanks!